### PR TITLE
Parse v2 JS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ cypress/TestCases/Distributor
 # External Testdata
 cypress/fixtures/external
 
+# Firebolt Calls Test Data
+cypress/fixtures/fireboltCalls/index.js
+# To be removed below
+cypress/fixtures/fireboltCallsJS/index.js
+
 # Lock Files
 yarn.lock
 

--- a/cypress/plugins/common.js
+++ b/cypress/plugins/common.js
@@ -17,12 +17,20 @@
  */
 const fs = require('fs');
 const logger = require('../support/Logger')('common.js');
+const { generateFirboltCallsIndexFile } = require('./pluginUtils');
 
 // If "genericSupport" is set to a falsy value (false, null, etc), take no further action. Simply "return"
 function genericSupport(config) {
   // Read additional config.
   try {
     const data = JSON.parse(fs.readFileSync('supportConfig.json'));
+
+    // Get fireboltCalls data from default path
+    // ***TODO: UPDATE TO CORRECT PATH**
+    generateFirboltCallsIndexFile('cypress/fixtures/fireboltCallsJS');
+    // Get fireboltCalls data from configModule
+    // ***TODO: UPDATE TO CORRECT PATH**
+    generateFirboltCallsIndexFile('node_modules/configModule/testData/fireboltCallsJS');
 
     // Get the arguments passed from command line during run time.
     const commandLineArgs = Object.entries(config.resolved.env)

--- a/cypress/support/cypress-support/src/main.js
+++ b/cypress/support/cypress-support/src/main.js
@@ -29,6 +29,9 @@ const logger = require('../../Logger')('main.js');
 const setimmediate = require('setimmediate');
 let appTransport;
 const flatted = require('flatted');
+// ***TODO: UPDATE TO CORRECT PATH**
+const internalFireboltCallsData = require('../../../fixtures/fireboltCallsJS/index');
+const externalFireboltCallsData = require('configModule/testData/fireboltCallsJS/index');
 
 export default function (module) {
   const config = new Config(module);
@@ -90,6 +93,10 @@ export default function (module) {
     const flattedOpenRpc = UTILS.getEnvVariable(CONSTANTS.DEREFERENCE_OPENRPC);
     const unflattedOpenRpc = flatted.parse(flattedOpenRpc);
     Cypress.env(CONSTANTS.DEREFERENCE_OPENRPC, unflattedOpenRpc);
+
+    // Update the line below to call custom merge function
+    const mergedFireboltCalls = { ...internalFireboltCallsData, ...externalFireboltCallsData };
+    console.log(JSON.stringify(mergedFireboltCalls));
   });
 
   // beforeEach


### PR DESCRIPTION
Takes in all V2 JS files and compiles them into JSON object for fireboltCalls fixture data.

WIP NOTES:
* Must update paths to point to `cypress/fixtures/fireboltCalls` instead of `cypress/fixtures/fireboltCallsJS`. Currently parsing issues exist when `.json` & `.js` files exist in the same directory. This should be fixed once V1 JSON gets resolved inside of the before plugin.
* Waiting on changes to configModules to change the name of testData directory to fixtures. This will result in another path change.
* All updates relating to path updates include the comment `***TODO: UPDATE TO CORRECT PATH**`
* Lastly, will need to figure out if I should wrap the two `generateFirboltCallsIndexFile(path)` calls inside of a single function that would be called inside of common.js.