### PR TITLE
Remove Tests for SDK Only Behavior Certification from platform Certification Modules & Fix Sanity Suites

### DIFF
--- a/cypress/TestCases/FireboltCertification/Manage/ClosedCaptionsManage.feature
+++ b/cypress/TestCases/FireboltCertification/Manage/ClosedCaptionsManage.feature
@@ -49,28 +49,6 @@ Feature: ClosedCaptions_Manage
             | Set windowOpacity-50                 | windowOpacity      | closedcaptions onWindowOpacityChanged      | set windowOpacity to 50                 | get windowOpacity      | 50 for windowOpacity in closedCaptions                 | onWindowOpacityChanged for closedcaptions with 50                 | null for closedCaptions setWindowOpacity      |
 
     @ClosedCaptions @manageSDK
-    Scenario Outline: ClosedCaptions.<Method> - Positive Scenario: <Scenario> with undefined params
-        When 1st party app invokes the 'Firebolt' API to '<API_Key>'
-        Then 'Firebolt' platform responds to '1st party app' with '<Method_Validation_Key>'
-
-        Examples:
-            | Scenario               | Method                | API_Key                                   | Method_Validation_Key                            |
-            | Set enabled            | setEnabled            | enable closedCaptions with no parameters  | enabled for closedCaptions setEnabled            |
-            | Set fontFamily         | setFontFamily         | set fontFamily with no parameters         | casual for closedCaptions setFontFamily          |
-            | Set fontSize           | setFontSize           | set fontSize with no parameters           | 1.5 for closedcaptions setFontSize               |
-            | Set fontColor          | setFontColor          | set fontColor with no parameters          | #ff00ff for closedcaptions setFontColor          |
-            | Set fontEdge           | setFontEdge           | set fontEdge with no parameters           | dropShadow right for closedcaptions setFontEdge  |
-            | Set fontEdgeColor      | setFontEdgeColor      | set fontEdgeColor with no parameters      | #ffffff for closedcaptions setFontEdgeColor      |
-            | Set fontOpacity        | setFontOpacity        | set fontOpacity with no parameters        | 75 for closedcaptions setFontOpacity             |
-            | Set backgroundColor    | setBackgroundColor    | set backgroundColor with no parameters    | #7f7f7f for closedcaptions setBackgroundColor    |
-            | Set backgroundOpacity  | setBackgroundOpacity  | set backgroundOpacity with no parameters  | 75 for closedcaptions setBackgroundOpacity       |
-            | Set textAlign          | setTextAlign          | set textAlign with no parameters          | right for closedcaptions setTextAlign            |
-            | Set textAlignVertical  | setTextAlignVertical  | set textAlignVertical with no parameters  | bottom for closedcaptions setTextAlignVertical   |
-            | Set windowColor        | setWindowColor        | set windowColor with no parameters        | white for closedcaptions setWindowColor          |
-            | Set windowOpacity      | setWindowOpacity      | set windowOpacity with no parameters      | 50 for closedcaptions setWindowOpacity           |
-            | Set preferredLanguages | setPreferredLanguages | set preferredLanguages with no parameters | spanish for closedcaptions setPreferredLanguages |
-
-    @ClosedCaptions @manageSDK
     Scenario Outline: Closedcaptions.<Method> - Positive Scenario: <Scenario> with 'null' params
         When 1st party app registers for the '<Event>' event using the 'Firebolt' API
         And 1st party app invokes the 'Firebolt' API to '<Set_API_Key>'

--- a/cypress/TestCases/FireboltCertification/Manage/VoiceGuidanceManage.feature
+++ b/cypress/TestCases/FireboltCertification/Manage/VoiceGuidanceManage.feature
@@ -20,15 +20,6 @@ Feature: VoiceGuidance_Manage
             | Set speed-1           | speed   | voiceguidance onspeedchanged   | set voiceguidance speed to 1 | get voiceguidance speed   | 1 for voiceguidance speed       | onSpeedChanged for voiceguidance with 1       | null for voiceguidance setSpeed   |
             | Set speed-2           | speed   | voiceguidance onspeedchanged   | set voiceguidance speed to 2 | get voiceguidance speed   | 2 for voiceguidance speed       | onSpeedChanged for voiceguidance with 2       | null for voiceguidance setSpeed   |
 
-    @ClosedCaptions @coreSDK @sdk @transport
-    Scenario Outline: Voiceguidance.<Method> - Positive Scenario: <Scenario> with undefined params
-        When 1st party app invokes the 'Firebolt' API to '<Key>'
-        Then 'Firebolt' platform responds to '1st party app' with '<Method_Content>'
-
-        Examples:
-            | Scenario             | Key                                     | Method_Content                        | Method  |
-            | Enable voiceguidance | enable voiceguidance with no parameters | enabled for voiceGuidance setEnabled  | enabled |
-            | speed-2              | set speed as 2 with no parameters       | 2 for speed in voiceGuidance setSpeed | speed   |
 
     @VoiceGuidance @manageSDK @sdk @transport
     Scenario Outline: Voiceguidance.<Method> - Negative Scenario: <Scenario> and expecting error

--- a/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
+++ b/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
@@ -1,0 +1,23 @@
+Feature: ClosedCaptions_SDK
+
+ @ClosedCaptions @manageSDK
+    Scenario Outline: ClosedCaptions.<Method> - Positive Scenario: <Scenario> with undefined params
+        When 1st party app invokes the 'Firebolt' API to '<API_Key>'
+        Then 'Firebolt' platform responds to '1st party app' with '<Method_Validation_Key>'
+
+        Examples:
+            | Scenario               | Method                | API_Key                                   | Method_Validation_Key                            |
+            | Set enabled            | setEnabled            | enable closedCaptions with no parameters  | enabled for closedCaptions setEnabled            |
+            | Set fontFamily         | setFontFamily         | set fontFamily with no parameters         | casual for closedCaptions setFontFamily          |
+            | Set fontSize           | setFontSize           | set fontSize with no parameters           | 1.5 for closedcaptions setFontSize               |
+            | Set fontColor          | setFontColor          | set fontColor with no parameters          | #ff00ff for closedcaptions setFontColor          |
+            | Set fontEdge           | setFontEdge           | set fontEdge with no parameters           | dropShadow right for closedcaptions setFontEdge  |
+            | Set fontEdgeColor      | setFontEdgeColor      | set fontEdgeColor with no parameters      | #ffffff for closedcaptions setFontEdgeColor      |
+            | Set fontOpacity        | setFontOpacity        | set fontOpacity with no parameters        | 75 for closedcaptions setFontOpacity             |
+            | Set backgroundColor    | setBackgroundColor    | set backgroundColor with no parameters    | #7f7f7f for closedcaptions setBackgroundColor    |
+            | Set backgroundOpacity  | setBackgroundOpacity  | set backgroundOpacity with no parameters  | 75 for closedcaptions setBackgroundOpacity       |
+            | Set textAlign          | setTextAlign          | set textAlign with no parameters          | right for closedcaptions setTextAlign            |
+            | Set textAlignVertical  | setTextAlignVertical  | set textAlignVertical with no parameters  | bottom for closedcaptions setTextAlignVertical   |
+            | Set windowColor        | setWindowColor        | set windowColor with no parameters        | white for closedcaptions setWindowColor          |
+            | Set windowOpacity      | setWindowOpacity      | set windowOpacity with no parameters      | 50 for closedcaptions setWindowOpacity           |
+            | Set preferredLanguages | setPreferredLanguages | set preferredLanguages with no parameters | spanish for closedcaptions setPreferredLanguages |

--- a/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
+++ b/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
@@ -1,6 +1,6 @@
 Feature: ClosedCaptions_SDK
 
- @ClosedCaptions @manageSDK
+    @ClosedCaptions @manageSDK
     Scenario Outline: ClosedCaptions.<Method> - Positive Scenario: <Scenario> with undefined params
         When 1st party app invokes the 'Firebolt' API to '<API_Key>'
         Then 'Firebolt' platform responds to '1st party app' with '<Method_Validation_Key>'

--- a/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
+++ b/cypress/TestCases/FireboltCertification/SDKBehavior/ClosedCaptions.feature
@@ -2,6 +2,8 @@ Feature: ClosedCaptions_SDK
 
     @ClosedCaptions @manageSDK
     Scenario Outline: ClosedCaptions.<Method> - Positive Scenario: <Scenario> with undefined params
+        Given the environment has been set up for 'ClosedCaptions' tests
+        And 3rd party 'certification' app is launched
         When 1st party app invokes the 'Firebolt' API to '<API_Key>'
         Then 'Firebolt' platform responds to '1st party app' with '<Method_Validation_Key>'
 

--- a/cypress/TestCases/FireboltCertification/SDKBehavior/VoiceGuidance.feature
+++ b/cypress/TestCases/FireboltCertification/SDKBehavior/VoiceGuidance.feature
@@ -1,0 +1,11 @@
+Feature: VoiceGuidance_SDK
+
+    @VoiceGuidance @coreSDK @sdk @transport
+    Scenario Outline: Voiceguidance.<Method> - Positive Scenario: <Scenario> with undefined params
+        When 1st party app invokes the 'Firebolt' API to '<Key>'
+        Then 'Firebolt' platform responds to '1st party app' with '<Method_Content>'
+
+        Examples:
+            | Scenario             | Key                                     | Method_Content                        | Method  |
+            | Enable voiceguidance | enable voiceguidance with no parameters | enabled for voiceGuidance setEnabled  | enabled |
+            | speed-2              | set speed as 2 with no parameters       | 2 for speed in voiceGuidance setSpeed | speed   |

--- a/cypress/TestCases/FireboltCertification/SDKBehavior/VoiceGuidance.feature
+++ b/cypress/TestCases/FireboltCertification/SDKBehavior/VoiceGuidance.feature
@@ -2,6 +2,8 @@ Feature: VoiceGuidance_SDK
 
     @VoiceGuidance @coreSDK @sdk @transport
     Scenario Outline: Voiceguidance.<Method> - Positive Scenario: <Scenario> with undefined params
+        Given the environment has been set up for 'Voiceguidance' tests
+        And 3rd party 'certification' app is launched
         When 1st party app invokes the 'Firebolt' API to '<Key>'
         Then 'Firebolt' platform responds to '1st party app' with '<Method_Content>'
 

--- a/cypress/TestCases/Sanity/CoreSDKSuite.feature
+++ b/cypress/TestCases/Sanity/CoreSDKSuite.feature
@@ -1,7 +1,7 @@
 Feature: Firebolt Certification Core-SDK validation
-  @mfos @sanity @coreSDK @Suite @sdk  @transport
+
+  @sanity @coreSDK @Suite @sdk @transport
   Scenario: Firebolt Certification Core-SDK validation
-    #check with kurt on multiple befores
     Given the environment has been set up for 'Firebolt Sanity' tests
     And 3rd party 'certification' app is launched
     Then User starts 'firebolt certification' test using below datatable

--- a/cypress/TestCases/Sanity/ManageSDKSuite.feature
+++ b/cypress/TestCases/Sanity/ManageSDKSuite.feature
@@ -1,16 +1,9 @@
 Feature: Firebolt Certification Manage-SDK validation
 
-  @mfos @sanity @ManageSDK @Suite @sdk @transport
-  Scenario: Setup environment for sanity
-    Given the environment has been set up for 'Firebolt Sanity' tests
-
-  @mfos
-  Scenario: Launch FCA for MFOS
-    And 3rd party 'certification' app is launched
-
-  @mfos @sanity @ManageSDK @Suite @sdk @transport
+  @sanity @ManageSDK @Suite @sdk @transport
   Scenario: Firebolt Certification Manage-SDK validation
-    Then User starts 'firebolt certification' test using below datatable
+    Given the environment has been set up for 'Firebolt Sanity' tests
+    And 3rd party 'certification' app is launched
+    When User starts 'firebolt certification' test using below datatable
       | paramType | variableName | value           |
       | INPUT     | action       | MANAGE          |
-      | CONFIG    | appId        | firstPartyAppId |


### PR DESCRIPTION
Test cases under Closed Captions and Voice Guidance using undefined parameters were originally implemented for use in signing off on SDK behavior when certifying a new SDK release. As this is not a platform certification test I am removing these tests from the platform certification folder and moving them to a new SDKBehavior directory.

Additionally rewriting Manage Sanity suite test case as the current test is invalid.