### PR TITLE
Move defaultTestData v2 variables to cypress env

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -62,6 +62,14 @@ const env = {
   loggerLevel: 'debug',
   testSuite: '',
   visibilityState: { foreground: 'visible', background: 'visible', inactive: 'hidden' },
+  defaultTestData: {
+    apiVersion: '1.0.0',
+    deviceResolution: [
+      [1280, 720],
+      [1920, 1080],
+      [3840, 2160],
+    ],
+  },
 };
 
 module.exports = {

--- a/cypress/fixtures/defaultTestData.json
+++ b/cypress/fixtures/defaultTestData.json
@@ -36,8 +36,6 @@
   "stringZero": "0",
   "stringOne": "1",
   "EMPTYARRAY": [],
-  "APIVERSION": "1.0.0",
-  "DEVICERESOLUTION" : [[1280,720],[1920,1080],[3840,2160]],
   "STRING123456": "123456",
   "FOREGROUND": "foreground"
 }

--- a/cypress/fixtures/objects/validationObjects/device.json
+++ b/cypress/fixtures/objects/validationObjects/device.json
@@ -21,7 +21,7 @@
                 "validations": [
                     {
                         "mode": "fixture",
-                        "type": "APIVERSION",
+                        "type": "CYPRESSENV-defaultTestData-apiVersion",
                         "description": "Validation of the Device version  API Format"
                     }
                 ]
@@ -81,7 +81,7 @@
                 "validations": [
                     {
                         "mode": "fixture",
-                        "type": "DEVICERESOLUTION",
+                        "type": "CYPRESSENV-defaultTestData-deviceResolution",
                         "description": "Validation of the Device videoResolution"
                     }
                 ]

--- a/cypress/plugins/testDataProcessor.js
+++ b/cypress/plugins/testDataProcessor.js
@@ -193,6 +193,37 @@ function testDataHandler(requestType, dataIdentifier, fireboltObject) {
                 if (typeof data.type !== CONSTANTS.STRING) {
                   return data.type;
                 }
+
+                // Resolve any cypress env variables
+                if (typeof data.type === 'string' && data.type.includes('CYPRESSENV')) {
+                  // Split into an array and remove CYPRESSENV
+                  const envSegments = data.type.split('-').slice(1);
+                  // Handle the case where the env variable is an object
+                  if (envSegments.length > 1) {
+                    const objectName = envSegments[0];
+                    const propertyName = envSegments[1];
+
+                    // Get object from envVariables
+                    const envValue = _.get(envVariables, [objectName, propertyName]);
+
+                    // Check if object exists and contains the specified property
+                    if (envValue !== undefined) {
+                      return (data.type = envValue);
+                    } else {
+                      logger.info(`Cypress env variable '${envKey}' does not exist`);
+                      return data.type;
+                    }
+                  } else {
+                    const envKey = envSegments[0];
+                    const envValue = _.get(envVariables, envKey);
+                    if (envValue !== undefined) {
+                      return (data.type = envValue);
+                    } else {
+                      logger.info(`Cypress env variable '${envKey}' does not exist`);
+                      return data.type;
+                    }
+                  }
+                }
                 switch (data.mode) {
                   case CONSTANTS.REGEX.toLowerCase():
                     const regexType = data.type.includes('_REGEXP')


### PR DESCRIPTION
This PR aims to improve how test data variables are managed, specifically with v2 test data in sight. `APIVERSION` and `DEVICERESOLUTION` were moved into a `defaultTestData` object within the Cypress environment. The following changes were made:

* Relocated `APIVERSION` and `DEVICERESOLUTION` from `defaultTestData.json` to a defaultTestData object in `cypress.config.js`.
* Updated validation objects in `device.json` to correctly access these variables from the Cypress environment.
* Modified the v1 `testDataHandler` logic to resolve the `CYPRESSENV` prefix when resolving validation objects.