### PR TITLE
RPPL-1875: Update fireboltCalls.js

### DIFF
--- a/cypress/support/step_definitions/fireboltCalls.js
+++ b/cypress/support/step_definitions/fireboltCalls.js
@@ -46,6 +46,7 @@ Given(/1st party app invokes the (?:'(.+)' )?API to '(.+)'$/, async (sdk, key) =
         params: params,
         action: action,
       };
+      Cypress.env(CONSTANTS.THIRD_PARTY_APP_ID, params.appId);
 
       cy.log('Call from 1st party App, method: ' + method + ' params: ' + JSON.stringify(params));
       cy.sendMessagetoPlatforms(requestMap).then((response) => {


### PR DESCRIPTION
[RPPL-1875](https://ccp.sys.comcast.net/browse/RPPL-1875)

- As part of the above ticket, we want to launch third party apps like Prime Video, Apple TV+, Hulu, etc. apart from FCA.
- I observed that, by default, the discovery.launch() method launches the app with appId CONSTANTS.THIRD_PARTY_APP_ID.
- Hence, with the proposed change, we are trying to update the CONSTANTS.THIRD_PARTY_APP_ID with any other appId, if present.
- I have verified that it is working fine while launching FCA or any other app.

