### PR TITLE
fix: change jsonschema dependency to static 1.4.1 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jsdom": "^24.0.0",
     "json-merger": "1.1.10",
     "jsonpath": "^1.1.1",
-    "jsonschema": "^1.4.0",
+    "jsonschema": "1.4.1",
     "lint": "^0.8.19",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",


### PR DESCRIPTION
Set jsonschema to static version 1.4.1 as minor release 1.5.0 of the jsonschema package contained breaking changes for older browsers and node versions.