### PR TITLE
Fix: Resolve multiple cypress env variables in fixtures at runtime

### DIFF
--- a/cypress/support/cypress-commands/commands.js
+++ b/cypress/support/cypress-commands/commands.js
@@ -95,11 +95,13 @@ Cypress.Commands.add('fireboltDataParser', (key, sdk = CONSTANTS.SUPPORTED_SDK[0
             }
           });
         } else {
-          const containEnv = Object.keys(params).find((key) => key.includes('CYPRESSENV'));
-          if (containEnv) {
-            const envParam = containEnv.split('-')[1];
-            params[envParam] = Cypress.env(envParam);
-            delete params[containEnv];
+          const envList = Object.keys(params).filter((key) => key.includes('CYPRESSENV'));
+          if(envList.length > 0) {
+            envList.forEach((item) => {
+              const envParam = item.split('-')[1];
+              params[envParam] = Cypress.env(envParam);
+              delete params[item];
+            })
           }
         }
 

--- a/cypress/support/cypress-support/src/main.js
+++ b/cypress/support/cypress-support/src/main.js
@@ -98,19 +98,19 @@ export default function (module) {
     } else {
       cy.log(CONSTANTS.PERFORMANCE_METRICS_NOT_ACTIVE);
     }
-    // Merge fireboltCalls
-    const v1FireboltCallsData = UTILS.getEnvVariable('fireboltCallsJson');
-    const v2FireboltCallsData = _.merge(
-      {},
-      internalV2FireboltCallsData,
-      externalV2FireboltCallsData
-    );
+    // Merge fireboltCalls - Commented temporarily. Moved to beforeEach
+    // const v1FireboltCallsData = UTILS.getEnvVariable('fireboltCallsJson');
+    // const v2FireboltCallsData = _.merge(
+    //   {},
+    //   internalV2FireboltCallsData,
+    //   externalV2FireboltCallsData
+    // );
 
-    cy.mergeFireboltCallJsons(v1FireboltCallsData, v2FireboltCallsData).then(
-      (mergedFireboltCalls) => {
-        Cypress.env(CONSTANTS.COMBINEDFIREBOLTCALLS, mergedFireboltCalls);
-      }
-    );
+    // cy.mergeFireboltCallJsons(v1FireboltCallsData, v2FireboltCallsData).then(
+    //   (mergedFireboltCalls) => {
+    //     Cypress.env(CONSTANTS.COMBINEDFIREBOLTCALLS, mergedFireboltCalls);
+    //   }
+    // );
 
     // Merge fireboltMocks
     const v1FireboltMockData = UTILS.getEnvVariable('fireboltMocksJson');
@@ -134,6 +134,20 @@ export default function (module) {
     cy.getBeforeOperationObject();
     cy.initiatePerformanceMetrics();
     UTILS.destroyGlobalObjects([CONSTANTS.LIFECYCLE_APP_OBJECT_LIST]);
+
+    // Merge fireboltCalls - Temporary fix to populate env variable between steps
+    const v1FireboltCallsData = UTILS.getEnvVariable('fireboltCallsJson');
+    const v2FireboltCallsData = _.merge(
+      {},
+      internalV2FireboltCallsData,
+      externalV2FireboltCallsData
+    );
+
+    cy.mergeFireboltCallJsons(v1FireboltCallsData, v2FireboltCallsData).then(
+      (mergedFireboltCalls) => {
+        Cypress.env(CONSTANTS.COMBINEDFIREBOLTCALLS, mergedFireboltCalls);
+      }
+    );
   });
 
   /**


### PR DESCRIPTION
Resolve multiple cypress env variables in fixtures at runtime